### PR TITLE
docs(requirements): document intentional pins behind WeblateOrg/docker main

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,10 @@
+# Pins intentionally lag https://github.com/WeblateOrg/docker/blob/main/requirements.txt
+# (upstream docker main tracks newer Weblate + Django). Keep this file aligned with
+# WEBLATE_VERSION in Dockerfile (currently 5.16.2 / Django 5.2 LTS), not with docker main.
+# High-signal deltas vs docker main when last reviewed: Django 5.2.x vs 6.x; redis 5.x vs 6.x;
+# altcha, gevent, django-celery-beat, djangorestframework, social-auth-* move with that stack.
+# Renovate (.github/renovate.json) may propose bumps—evaluate against WEBLATE + boost-weblate, not
+# blindly to match docker main.
 aeidon==1.15
 ahocorasick-rs==1.0.3
 aliyun-python-sdk-alimt==3.2.0
@@ -22,7 +29,7 @@ django-otp-webauthn==0.8.0
 django-redis==6.0.0
 django_compressor==4.6.0
 djangorestframework==3.16.1
-# Alernative Celery pool implementation
+# Alternative Celery pool implementation
 gevent==25.9.1
 git-review==2.5.0
 google-cloud-translate==3.24.0


### PR DESCRIPTION
## Summary

Adds a short comment block at the top of `requirements.txt` explaining why our pins intentionally lag [WeblateOrg/docker `main`](https://github.com/WeblateOrg/docker/blob/main/requirements.txt): they track **`WEBLATE_VERSION` in the Dockerfile** (Weblate 5.16.x / Django 5.2 LTS), not upstream docker’s newer stack (e.g. Django 6, redis 6).

Also fixes the gevent comment typo (`Alernative` → `Alternative`) and ensures a newline at end of file.

## Context

- High-signal deltas called out in comments: Django 5.2 vs 6, redis 5 vs 6, and related packages (altcha, gevent, django-celery-beat, DRF, social-auth) that move with the Weblate/Django upgrade.
- Notes that Renovate (`.github/renovate.json`) bumps should be judged against **WEBLATE + boost-weblate**, not merged blindly to match docker `main`.
