### PR TITLE
#6 : Add some documentations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ used by over 2500 libre projects and companies in more than 165 countries.**
 
 The webserver is running on the port 8080.
 
+## Operations / deployment
+
+**Repositories:** **`weblate`** (application fork) and **`weblate-docker`** (this repo). Your checkout folder name may differ—many installs clone **`weblate`** into a directory called **`boost-weblate`** (the Docker build context), with **`weblate-docker/`** as a submodule beside it.
+
+[`docker-compose.yml`](docker-compose.yml) uses `context: ..` and `dockerfile: weblate-docker/Dockerfile`. Production CD (see **`weblate`** `.github/workflows/cd.yml`) also copies [`weblate-docker/.dockerignore`](.dockerignore) to the application root before `docker compose up --build`.
+
+- [Deployment overview](docs/deployment-overview.md) — scope, components, environments, ops handoff
+- [Deployment runbook](docs/deployment-runbook.md) — setup, health checks, upgrade and rollback, CI/CD sequence
+
 ## Documentation
 
 Detailed documentation is available in [Weblate documentation][doc].

--- a/docs/deployment-overview.md
+++ b/docs/deployment-overview.md
@@ -1,0 +1,117 @@
+# Deployment overview
+
+This document describes what the Boost Weblate Docker Compose stack covers, how its pieces fit together, and how operations should record environment-specific details. For procedural steps (setup, health checks, rollback), see [deployment-runbook.md](deployment-runbook.md).
+
+## Scope
+
+**In scope**
+
+- Running Boost Weblate from this repository’s [`docker-compose.yml`](../docker-compose.yml): **Valkey** (`cache` service), the **Weblate application** container (`weblate`), and **Docker volumes** for application data and caches.
+- Configuration via an `environment` file (copy from [`environment.example`](../environment.example)), consistent with [upstream Weblate Docker environment variables](https://docs.weblate.org/en/latest/admin/install/docker.html#generic-settings).
+- **PostgreSQL** as a database **outside** this Compose file by default (see `POSTGRES_*` in `environment.example`). You provide connectivity from the Weblate container (for example `host.docker.internal` on Docker Desktop–style hosts).
+
+**Out of scope (operator-owned)**
+
+- TLS termination, reverse proxies, load balancers, CDN, and DNS in front of the stack.
+- Hosting and backup policy for PostgreSQL itself (only the connection expectations from Weblate’s perspective are described here).
+- Organization-specific monitoring, paging, and incident management beyond the health endpoints this image exposes.
+
+## Repository layout
+
+Git **repository names** are **`weblate`** (application fork) and **`weblate-docker`** (this repository). The directory you clone into is independent—often named after the deployment (for example **`boost-weblate`** on disk).
+
+| Git repository | Checkout folder (example) | Role |
+|----------------|---------------------------|------|
+| **`weblate`** | e.g. `boost-weblate/` | Application sources copied into the image at build time (`COPY .. /app/boost-weblate/` in the Dockerfile). |
+| **`weblate-docker`** | **`weblate-docker/`** submodule inside that tree | Dockerfile, Compose, nginx/supervisor layout, patches (this repo). |
+
+[`docker-compose.yml`](../docker-compose.yml) sets `build.context` to the **parent directory** and `dockerfile: weblate-docker/Dockerfile`, so the application root **must** contain **`weblate-docker/`** next to the Python tree.
+
+**Submodule workflow (typical)**
+
+```bash
+git clone --recurse-submodules <weblate-repo-url> boost-weblate
+cd boost-weblate
+# If submodules were not initialized:
+git submodule update --init weblate-docker
+```
+
+**Equivalent manual layout** (folder name `boost-weblate` is only an example)
+
+```
+boost-weblate/          # clone of repo `weblate` — Docker build context ..
+  weblate-docker/       # clone / submodule of repo `weblate-docker`
+    docker-compose.yml
+    Dockerfile
+    ...
+```
+
+Run Compose from `<application-root>/weblate-docker/` (for example `boost-weblate/weblate-docker/`).
+
+### Automated deploy (reference)
+
+The **`weblate`** application repository defines CD in **`.github/workflows/cd.yml`**. That workflow deploys over SSH into **`/opt/boost-weblate`** on the server: `git pull`, `git submodule update --init weblate-docker`, copies **`weblate-docker/.dockerignore`** to the application root for the Docker build context, then runs **`docker compose down`** and **`docker compose up -d --build`** from **`weblate-docker/`**, and finally probes **`http://localhost:8000/healthz/`** after a startup wait. If your checkout path or workflow differs, follow your fork’s YAML—this section describes the intended shape.
+
+## Components
+
+```mermaid
+flowchart LR
+  subgraph clients [Clients]
+    B[Browser_and_API_clients]
+  end
+  subgraph edge [Optional operator edge]
+    P[Reverse_proxy_TLS]
+  end
+  subgraph compose ["Docker Compose stack"]
+    W[weblate_container]
+    V[cache_Valkey]
+    VD[(weblate-data_volume)]
+    VC[(weblate-cache_volume)]
+    RD[(redis-data_volume)]
+  end
+  subgraph external [External]
+    PG[(PostgreSQL)]
+  end
+  B --> P
+  P --> W
+  B --> W
+  W --> PG
+  W --> V
+  W --> VD
+  W --> VC
+  V --> RD
+```
+
+- **`weblate` service:** nginx + Django + Celery workers (supervisor). Exposes **8080** inside the container; the sample Compose maps **8000:8080** on the host.
+- **`cache` service:** Valkey for Redis-compatible caching (`REDIS_HOST=cache` in `environment.example`).
+- **Volumes:** Persistent Weblate data under `/app/data`, cache under `/app/cache`, Valkey data for the cache service.
+
+Fork-specific behaviour (QuickBook, AsciiDoc, OpenRouter translation, `/boost-endpoint/`, and related settings) is documented in the Boost Weblate additions chapter—see [References](#references).
+
+## Environments
+
+Replace placeholders with values for your organization. Do not commit real secrets.
+
+| Environment | Purpose | Public URL | Image tag / digest strategy | PostgreSQL endpoint (label) | Notes |
+|-------------|---------|------------|------------------------------|-----------------------------|-------|
+| Development | _TBD_ | _TBD_ | _e.g. Compose `image` + git SHA_ | _TBD_ | _TBD_ |
+| Staging | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| Production | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+
+## Operations handoff checklist
+
+Use this when transferring ownership or onboarding on-call engineers.
+
+- [ ] **Service owner** and **escalation path** (team, chat channel, ticket queue).
+- [ ] **Source of truth** for deploys: for example the **`weblate`** repo’s **`.github/workflows/cd.yml`** (`workflow_dispatch` over SSH), a registry image workflow, or manual `docker compose build` from tagged revisions. Record the server checkout path (for example **`/opt/boost-weblate`**).
+- [ ] **Secrets:** `environment` file (not committed), or Docker secrets / `_FILE` variables as supported by [`start`](../start). Document where credentials are stored (vault, password manager, cloud secret store).
+- [ ] **Database:** Who operates PostgreSQL, backup schedule, restore drill procedure. Link to [Weblate backup documentation](https://docs.weblate.org/en/latest/admin/backup.html).
+- [ ] **Monitoring:** Health endpoint `/healthz/` (see [deployment-runbook.md](deployment-runbook.md)), optional `SENTRY_DSN` / `SENTRY_ENVIRONMENT` in `environment.example`.
+- [ ] **Mail and integrations:** SMTP (`WEBLATE_EMAIL_*`), VCS credentials (`WEBLATE_GITHUB_*`, etc.) as required.
+- [ ] **Boost fork options:** OpenRouter and related env vars—see [References](#references).
+
+## References
+
+- **Runbook:** [deployment-runbook.md](deployment-runbook.md)
+- **Weblate (upstream):** [Docker installation](https://docs.weblate.org/en/latest/admin/install/docker.html), [Backup](https://docs.weblate.org/en/latest/admin/backup.html), [Upgrading](https://docs.weblate.org/en/latest/admin/upgrade.html)
+- **Boost Weblate fork:** `docs/admin/boost-weblate.rst` in the **`weblate`** repository (Sphinx source for fork-specific configuration and HTTP APIs). Your checkout directory may use another name (for example **`boost-weblate`**). Use your project’s published docs URL if available.

--- a/docs/deployment-runbook.md
+++ b/docs/deployment-runbook.md
@@ -1,0 +1,142 @@
+# Deployment runbook
+
+Procedures for initial setup, verifying health, upgrading and rolling back, and Boost-specific configuration pointers. For architecture and environment tables, see [deployment-overview.md](deployment-overview.md).
+
+## Prerequisites
+
+- **Docker** and **Docker Compose v2** on the host.
+- **Directory layout:** Git repo **`weblate-docker`** (this tree) must live as **`weblate-docker/`** under the root of the **`weblate`** application checkout so [`docker-compose.yml`](../docker-compose.yml) can use `build.context: ..` and `dockerfile: weblate-docker/Dockerfile`. The parent folder’s name is arbitrary (for example **`boost-weblate`** locally or **`/opt/boost-weblate`** on the deployment server). See [deployment-overview.md](deployment-overview.md#repository-layout) and the **`weblate`** repo’s **`.github/workflows/cd.yml`** for an automated deploy sequence. Initialize the submodule or reproduce the same tree manually.
+- **PostgreSQL** reachable from the Weblate container. The sample [`environment.example`](../environment.example) uses `POSTGRES_HOST=host.docker.internal` for a database on the host; adjust for your network (same Docker network as a `postgres` service, cloud RDS, etc.).
+- **Resources:** Follow [upstream production guidance](https://docs.weblate.org/en/latest/admin/install.html) for sizing; migrations may take several minutes on first start (`HEALTHCHECK` start period is five minutes in [`Dockerfile`](../Dockerfile)).
+
+## Initial setup
+
+1. From the **`weblate`** application root (example path **`boost-weblate/`**), ensure **`weblate-docker/`** is populated (submodule or clone).
+2. **Recommended** when mirroring production CI: from that same application root, copy the Docker ignore file into the build context (see **`weblate`** `.github/workflows/cd.yml`):
+
+   ```bash
+   cp weblate-docker/.dockerignore .dockerignore
+   ```
+
+3. Change into this directory:
+
+   ```bash
+   cd weblate-docker
+   ```
+
+4. Create local env file:
+
+   ```bash
+   cp environment.example environment
+   ```
+
+5. Edit **`environment`** (do not commit). At minimum set PostgreSQL variables (`POSTGRES_*`), `WEBLATE_ADMIN_PASSWORD` (or `WEBLATE_ADMIN_PASSWORD_FILE`), and secrets required for your deployment. See [Weblate generic Docker settings](https://docs.weblate.org/en/latest/admin/install/docker.html#generic-settings).
+
+6. Build and start:
+
+   ```bash
+   docker compose build
+   docker compose up -d
+   ```
+
+7. **Port mapping:** Default Compose publishes **8000** on the host → **8080** in the container. Browse `http://localhost:8000/` (or your host) and sign in with the admin user configured via `WEBLATE_ADMIN_EMAIL` / `WEBLATE_ADMIN_PASSWORD`.
+
+8. Optional sanity check inside the stack:
+
+   ```bash
+   docker compose exec weblate weblate check --deploy
+   ```
+
+   Resolve reported issues before relying on the instance in production.
+
+## Production deploy (matches `weblate` CI/CD)
+
+If you use the **`workflow_dispatch`** CD workflow in the **`weblate`** repo (`.github/workflows/cd.yml`), the remote script effectively runs:
+
+```bash
+cd /opt/boost-weblate
+git pull origin develop
+git submodule update --init weblate-docker
+cp weblate-docker/.dockerignore .dockerignore
+cd weblate-docker
+docker compose down
+docker compose up -d --build
+```
+
+After the containers restart, that workflow waits five minutes then verifies **`http://localhost:8000/healthz/`** from the host (same port mapping as [Initial setup](#initial-setup)). Align branch names (`develop`) and paths with your fork if they differ.
+
+## Health checks
+
+### Container health (Docker `HEALTHCHECK`)
+
+The image defines a `HEALTHCHECK` that runs [`health_check`](../health_check). It:
+
+1. **HTTP:** If the web stack is enabled, requests **`/healthz/`** — either `http://localhost:8080/healthz/` or `https://localhost:4443/healthz/` when TLS certs exist under `/app/data/ssl/`.
+2. **Supervisor:** Runs `supervisorctl status`. Exit code **3** is treated as success (expected when one-shot services differ); other failures fail the check.
+3. **Processes:** Fails if any supervised program is not in the expected running/stopped state (see script comments for `check`).
+
+Inspect status:
+
+```bash
+docker compose ps
+docker inspect --format='{{.State.Health.Status}}' <weblate_container_id>
+```
+
+### External monitoring
+
+Probe the same path your users reach, for example:
+
+- `http://<host>:8000/healthz/` with default port mapping, or
+- `https://<your-domain>/healthz/` behind a reverse proxy.
+
+Use timeouts consistent with your SLA; the script uses `curl --max-time 30` for the internal check.
+
+## Upgrades
+
+1. **Read** [Weblate upgrade notes](https://docs.weblate.org/en/latest/admin/upgrade.html) and your release’s changelog.
+2. **Back up the database** (and optional file backup for `/app/data`) per [Weblate backup](https://docs.weblate.org/en/latest/admin/backup.html).
+3. Check out updated **`weblate`** and **`weblate-docker`** revisions (matching tags or branches your team uses).
+4. Rebuild and recreate:
+
+   ```bash
+   cd weblate-docker
+   docker compose build --no-cache   # optional, when you need a clean dependency layer
+   docker compose up -d
+   ```
+
+   The entrypoint runs migrations as part of startup; allow time for the health check to pass after deploy.
+
+5. Verify **`/healthz/`**, application login, and background tasks (Celery) if you use them heavily.
+
+## Rollback
+
+Weblate upgrades apply **forward-only Django migrations**. Rolling back **only** the container to an older image while the database has already migrated forward can fail or corrupt data.
+
+**Safer rollback pattern**
+
+1. **Redeploy the previous image** you used before the failed release (tag or digest recorded in your environment table).
+2. If **database migrations ran** during the failed deploy, **restore PostgreSQL from the backup taken immediately before that upgrade**, then start the old image against that restored database.
+
+If you did not take a backup before upgrading, treat rollback as **high risk**; prefer fixing forward or restoring from the last known-good backup.
+
+Operational steps:
+
+```bash
+cd weblate-docker
+# Example: use a previously tagged image (adjust tag to your registry workflow)
+docker compose pull weblate   # if using a registry tag
+docker compose up -d weblate
+```
+
+Confirm `docker compose ps` and `/healthz/` before declaring the rollback complete.
+
+## Boost-specific configuration
+
+Fork-only environment variables (OpenRouter batch translation, Boost endpoint timing, etc.) are documented in the Boost Weblate additions chapter in the **`weblate`** repo: **`docs/admin/boost-weblate.rst`**. Cross-check [`environment.example`](../environment.example) for variables such as `OPENROUTER_API_KEY`, `OPENROUTER_MODEL`, `AUTO_BATCH_TRANSLATE_VIA_OPENROUTER`, and `BOOST_ENDPOINT_ADD_TRANSLATION_SECONDS`.
+
+## See also
+
+- [deployment-overview.md](deployment-overview.md)
+- [Weblate: Docker](https://docs.weblate.org/en/latest/admin/install/docker.html)
+- [Weblate: Backup](https://docs.weblate.org/en/latest/admin/backup.html)
+- [Weblate: Upgrade](https://docs.weblate.org/en/latest/admin/upgrade.html)


### PR DESCRIPTION
Close https://github.com/cppalliance/weblate-docker/issues/6

- Deployment overview (scope, components, environments with org-specific placeholders, link to runbook, ops handoff).
- Deployment runbook: setup, rollback, health checks aligned with this repo.